### PR TITLE
Use PS1-type vertex color formula

### DIFF
--- a/src/FrameBuffer.js
+++ b/src/FrameBuffer.js
@@ -1,11 +1,11 @@
 import {
   DataTexture,
   NearestFilter,
-  MeshBasicMaterial,
   Mesh,
   BoxGeometry,
   RGBAFormat,
 } from './three.js';
+import { newVSMaterial } from './VSTOOLS.js';
 
 const WIDTH = 1024;
 const HEIGHT = 512;
@@ -30,7 +30,7 @@ export class FrameBuffer {
   }
 
   build() {
-    this.material = new MeshBasicMaterial({
+    this.material = newVSMaterial({
       map: this.texture,
       flatShading: true,
       transparent: false,

--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -379,14 +379,13 @@ export function Viewer() {
           object.material = object.originalMaterial;
         }
 
-        if (noTexture && object.material.map) {
-          object.material.originalMap = object.material.map;
-          object.material.map = null;
+        if (noTexture && object.material.defines.USE_MAP) {
+          object.material.defines.USE_MAP = false;
           object.material.needsUpdate = true;
         }
 
-        if (!noTexture && !object.material.map && object.material.originalMap) {
-          object.material.map = object.material.originalMap;
+        if (!noTexture && !object.material.defines.USE_MAP) {
+          object.material.defines.USE_MAP = true;
           object.material.needsUpdate = true;
         }
 

--- a/src/WEP.js
+++ b/src/WEP.js
@@ -2,12 +2,12 @@ import {
   BufferGeometry,
   Skeleton,
   Float32BufferAttribute,
-  MeshBasicMaterial,
   SkinnedMesh,
   Bone,
   VertexColors,
   MeshNormalMaterial,
 } from './three.js';
+import { newVSMaterial } from './VSTOOLS.js';
 import { WEPVertex } from './WEPVertex.js';
 import { WEPBone } from './WEPBone.js';
 import { WEPFace } from './WEPFace.js';
@@ -284,7 +284,7 @@ export class WEP {
       return;
     }
 
-    this.material = new MeshBasicMaterial({
+    this.material = newVSMaterial({
       map: this.textureMap.textures[0],
       flatShading: true,
       skinning: true,

--- a/src/WEPFace.js
+++ b/src/WEPFace.js
@@ -42,21 +42,21 @@ export class WEPFace {
 
     // size of triangle is 16, quad is 20
 
-    // default vertex color is white
-    this.r1 = 255;
-    this.g1 = 255;
-    this.b1 = 255;
-    this.r2 = 255;
-    this.g2 = 255;
-    this.b2 = 255;
-    this.r3 = 255;
-    this.g3 = 255;
-    this.b3 = 255;
+    // default vertex color is 0x80
+    this.r1 = 0x80;
+    this.g1 = 0x80;
+    this.b1 = 0x80;
+    this.r2 = 0x80;
+    this.g2 = 0x80;
+    this.b2 = 0x80;
+    this.r3 = 0x80;
+    this.g3 = 0x80;
+    this.b3 = 0x80;
 
     if (this.quad()) {
-      this.r4 = 255;
-      this.g4 = 255;
-      this.b4 = 255;
+      this.r4 = 0x80;
+      this.g4 = 0x80;
+      this.b4 = 0x80;
     }
   }
 

--- a/src/ZND.js
+++ b/src/ZND.js
@@ -1,4 +1,5 @@
-import { MeshBasicMaterial, VertexColors } from './three.js';
+import { VertexColors } from './three.js';
+import { newVSMaterial } from './VSTOOLS.js';
 import { FrameBuffer } from './FrameBuffer.js';
 import { TIM } from './TIM.js';
 
@@ -137,7 +138,7 @@ export class ZND {
       this.textures.push(texture);
 
       // build texture
-      material = new MeshBasicMaterial({
+      material = newVSMaterial({
         map: texture,
         flatShading: true,
         transparent: true,


### PR DESCRIPTION
Hey, I love the viewer.

I noticed the vertex color formula is off. The PS1 combines texture and vertex color with `2 * texcolor * vertcolor` instead of the usual `texcolor * vertcolor` (used by Three's MeshBasicMaterial). Here's a patch that replaces MeshBasicMaterial with a shader that does the PS1 formula.

Comparison with map009 (Entrance to Darkness):

![Entrance to Darkness Comparison ](https://user-images.githubusercontent.com/11024420/141608243-b631937c-1366-45b1-b5e2-7393c68de18f.png)

Actually when using vertex colors with textures, 0x80 (128/255) is "fully bright" (no change to the texture), so the factor is a bit less than 2, 1.9922 (=255/128).

I don't know anything about Three so I wrote the new ShaderMaterial by closely following the MeshBasicMaterial shaders ([1](https://github.com/mrdoob/three.js/blob/r117/src/renderers/shaders/ShaderLib/meshbasic_vert.glsl.js), [2](https://github.com/mrdoob/three.js/blob/r117/src/renderers/shaders/ShaderLib/meshbasic_frag.glsl.js)). The factor is added to the vertex shader. I also noticed MeshBasicMaterial does some linear color space conversion stuff that I don't think should be there so I left it out.

I feel like it's a bit messy but hopefully you can make something of it anyway -A-